### PR TITLE
Addition to "popular projects" in comparison.md

### DIFF
--- a/content/docs/reference/comparison.md
+++ b/content/docs/reference/comparison.md
@@ -25,6 +25,7 @@ with similar goals to Pomksy. Here's a list of the most popular projects:
 | [Egg Expressions][egg-expressions]       | _Transpiled_<br>_App_: Oil shell |
 | [Rx Expressions][emacs-rx]               | _Transpiled_<br>_App_: Emacs     |
 | [Raku Grammars][raku-grammars]           | _App_: Raku                      |
+| [Ribose]                                 | _DSL_: Java                      |
 | [Rosie]                                  | _App_: Rosie                     |
 | [SRL]                                    | _DSL_: PHP                       | {{<gh-stars SimpleRegex SRL-PHP >}}                   |
 | [Super Expressive][super-expressive]     | _DSL_: JS                        | {{<gh-stars francisrstokes super-expressive >}}       |
@@ -36,6 +37,7 @@ with similar goals to Pomksy. Here's a list of the most popular projects:
 [melody]: https://github.com/yoav-lavi/melody
 [pomsky]: https://pomsky-lang.org/
 [raku-grammars]: https://www.perl.com/article/perl-6-grammers-part-1/
+[ribose]: https://github.com/jrte/ribose/
 [rosie]: https://rosie-lang.org/
 [srl]: https://github.com/SimpleRegex/SRL-PHP
 [super-expressive]: https://github.com/francisrstokes/super-expressive


### PR DESCRIPTION
I added [ribose](https://github.com/jrte/ribose) to the popular projects table if only to promote some rethinking about the utility of the technology underlying most of these projects, which derives more or less directly from work done by Thompson et al in the early unix days. The syntax is cranky (a problem that some of the frameworks above work to ameliorate) and they present limited support for fine-grained interaction with high-level code. 

Ribose is a ship-in-a-bottle demonstration of how [ginr](https://github.com/ntozubod/ginr), an industrial strength compiler for multidimensional regular expressions, can be harnessed to compile multitape transducers mapping input symbols (bytes) to non-branching vectors of simple effector methods expressed for a task-specfic object model. 

Ginr is the real gem in the ribose framework, but I'm not trying to sell anything here other than the general idea that there is a better way to harness (real) regular expressions for stream processing tasks ...