### PR TITLE
Fix broken hyperlink to playground

### DIFF
--- a/content/docs/get-started/quick-start.md
+++ b/content/docs/get-started/quick-start.md
@@ -15,7 +15,7 @@ toc: true
 
 ## Playground
 
-Using [the playground](https://playground.pomsky-lang/) is the easiest and most convenient
+Using [the playground](https://playground.pomsky-lang.org/) is the easiest and most convenient
 way to get started using pomsky. It supports syntax highlighting and shows errors directly in your
 code.
 


### PR DESCRIPTION
# Issue

Quick Start page's hyperlink to the playground is broken.

# Solution

Added `.org`